### PR TITLE
Fix group detection method

### DIFF
--- a/MainModule.ModuleScript.lua
+++ b/MainModule.ModuleScript.lua
@@ -652,11 +652,11 @@ local function GetAwayGroup( )
 			
 			for b = 1, #Groups do
 				
-				AllGroups[ Groups[ b ] ] = ( AllGroups[ Groups[ b ] ] or 0 ) + ( Groups[ b ].IsPrimary and 2 or 1 )
+				AllGroups[ Groups[ b ].Id ] = ( AllGroups[ Groups[ b ].Id ] or 0 ) + ( Groups[ b ].IsPrimary and 2 or 1 )
 				
-				if not Highest or AllGroups[ Groups[ b ] ] > AllGroups[ Highest ] then
+				if not Highest or AllGroups[ Groups[ b ].Id ] > AllGroups[ Highest ] then
 					
-					Highest = Groups[ b ]
+					Highest = Groups[ b ].Id
 					
 				end
 				


### PR DESCRIPTION
It was originally trying to compare two different tables with the same contents, but they're still recognized as two different tables in Lua. I changed it so it uses the group IDs instead.